### PR TITLE
fix: 修复九莲宝灯番数计算，添加对副露组数的检查

### DIFF
--- a/open_mahjong_server/server/game_calculation/guobiao_hepai_check.py
+++ b/open_mahjong_server/server/game_calculation/guobiao_hepai_check.py
@@ -8,6 +8,7 @@ class PlayerTiles:
     def __init__(self, tiles_list, combination_list,complete_step):
         self.hand_tiles = sorted(tiles_list)
         self.combination_list = combination_list
+        self.initial_combination_count = len(combination_list)
         self.complete_step = complete_step # +3 +3 +3 +3 +2 = 14
         self.fan_list = []
         self.point_count_dict = {} # 存储和牌得分
@@ -17,6 +18,7 @@ class PlayerTiles:
         new_instance = PlayerTiles(self.hand_tiles[:],
                                  self.combination_list[:],
                                  self.complete_step)
+        new_instance.initial_combination_count = self.initial_combination_count
         new_instance.fan_list = self.fan_list[:]
         return new_instance
 
@@ -517,7 +519,7 @@ class Chinese_Hepai_Check:
                     rank = i % 10
                     save_list.append(rank)
                 self.debug_print(save_list)
-                if save_list == self.jiulianbaodeng_list:
+                if player_tiles.initial_combination_count == 0 and save_list == self.jiulianbaodeng_list:
                     player_tiles.fan_list.append("jiulianbaodeng") # 九莲宝灯
                 else:
                     player_tiles.fan_list.append("qingyise") # 清一色
@@ -1431,6 +1433,8 @@ if __name__ == "__main__":
     # 2 test_save = [[],[21,21,21,22,23,24,25,26,27,28,29,29,29,23],23,["自摸"]] 90
     # 3 test_save = [[],[31,31,31,32,33,34,35,36,37,38,39,39,39,36],36,["点和"]] 89
     # 4 test_save = [[],[21,21,21,22,23,24,25,26,27,28,29,29,29,25],25,["自摸"]] 92
+    # 九莲宝灯牌型副露
+    # 1 test_save = [["s28"],[21,21,21,22,23,24,25,26,29,29,24],24,["点和"]] 26 # 有副露，不计九莲宝灯
     # 四杠
     # 1 test_save = [["G16","G28","G32","G44"],[29,29],29,["点和"]] 153
     # 2 test_save = [["G36","g31","G38","G12"],[35,35],35,["自摸"]] 108


### PR DESCRIPTION
运行测试数据
```
test_save = [["s28"],[21,21,21,22,23,24,25,26,29,29,24],24,["点和"]]
```
下得到的结果为：
```
传参手牌： [21, 21, 21, 22, 23, 24, 24, 25, 26, 29, 29] 传参组合： ['s28'] 传参和牌方式： ['点和'] 传参和牌张： 24
player_tiles: [21, 21, 21, 22, 23, 24, 24, 25, 26, 29, 29] 3 ['s28']
所有雀头可能 [[21, 22, 23, 24, 24, 25, 26, 29, 29], [21, 21, 21, 22, 23, 25, 26, 29, 29], [21, 21, 21, 22, 23, 24, 24, 25, 26], [21, 21, 21, 22, 23, 24, 24, 25, 26, 29, 29]]
计算次数： 56
和牌类型的数量: 1
手牌 [] 胡牌步数 14 胡牌组合 ['K21', 'S23', 'S25', 'q29', 's28']
组合映射： K21S23S25q29s28
手牌映射： [21, 21, 21, 22, 23, 24, 24, 25, 26, 27, 28, 29, 29, 29]
手牌 [21, 21, 21, 22, 23, 24, 24, 25, 26, 27, 28, 29, 29, 29]
temp_tiles_list [21, 21, 21, 22, 23, 24, 24, 25, 26, 27, 28, 29, 29, 29]
[1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9]
搭子标记： ['23', '25', '28']
刻子标记： ['21']
['K21', 'S23', 'S25', 'q29', 's28']
现在存在的组合 ['K21', 'S23', 'S25', 'q29', 's28']
全部被添加的番种 ['jiulianbaodeng', 'wuzi', 'yaojiuke', 'lianliu']
需要被阻挡的番种 ['qingyise', 'wuzi', 'menqianqing']
需要移除的幺九刻数量 1
重复番种 ['lianliu']
最终番种 ['jiulianbaodeng', 'lianliu']
添加番数jiulianbaodeng,88
添加番数lianliu,1
和牌文本 ['九莲宝灯', '连六*1']
和牌得分 89
```

这显然是不正确的，在加入对副露组数统计后：

```
传参手牌： [21, 21, 21, 22, 23, 24, 24, 25, 26, 29, 29] 传参组合： ['s28'] 传参和牌方式： ['点和'] 传参和牌张： 24
player_tiles: [21, 21, 21, 22, 23, 24, 24, 25, 26, 29, 29] 3 ['s28']
所有雀头可能 [[21, 22, 23, 24, 24, 25, 26, 29, 29], [21, 21, 21, 22, 23, 25, 26, 29, 29], [21, 21, 21, 22, 23, 24, 24, 25, 26], [21, 21, 21, 22, 23, 24, 24, 25, 26, 29, 29]]
计算次数： 56
和牌类型的数量: 1
手牌 [] 胡牌步数 14 胡牌组合 ['K21', 'S23', 'S25', 'q29', 's28']
组合映射： K21S23S25q29s28
手牌映射： [21, 21, 21, 22, 23, 24, 24, 25, 26, 27, 28, 29, 29, 29]
手牌 [21, 21, 21, 22, 23, 24, 24, 25, 26, 27, 28, 29, 29, 29]
temp_tiles_list [21, 21, 21, 22, 23, 24, 24, 25, 26, 27, 28, 29, 29, 29]
[1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9]
搭子标记： ['23', '25', '28']
刻子标记： ['21']
['K21', 'S23', 'S25', 'q29', 's28']
现在存在的组合 ['K21', 'S23', 'S25', 'q29', 's28']
全部被添加的番种 ['qingyise', 'wuzi', 'yaojiuke', 'lianliu']
需要被阻挡的番种 ['wuzi']
需要移除的幺九刻数量 0
重复番种 ['lianliu']
最终番种 ['qingyise', 'yaojiuke', 'lianliu']
添加番数qingyise,24
添加番数lianliu,1
添加番数yaojiuke,1
和牌文本 ['清一色', '连六*1', '幺九刻*1']
和牌得分 26
```