### PR TITLE
fix(jiandan): 使用 master_seed 派生牌山随机种子

### DIFF
--- a/open_mahjong_server/server/gamestate/game_jiandan/JiandanGameState.py
+++ b/open_mahjong_server/server/gamestate/game_jiandan/JiandanGameState.py
@@ -10,7 +10,7 @@ from .init_tiles import init_jiandan_tiles
 from .settlement import JiandanSettlementPolicy
 from ..public.hand_slot_utils import has_draw_slot, pick_timeout_discard_tile
 from ..public.logic_common import back_current_num
-from ..public.random_seed_manager import setup_random_seed_system
+from ..public.random_seed_manager import derive_round_seed, setup_random_seed_system
 from ..public.round_end_timing import liuju_ready_wait_seconds
 from ..public.vote_manager import vote_checkpoint
 
@@ -1085,8 +1085,7 @@ class JiandanGameState:
         }
 
     def _derive_round_seed(self) -> int:
-        seed = self.room_random_seed or 1
-        return seed * 1009 + self.current_round
+        return derive_round_seed(self.master_seed, self.current_round)
 
     def advance_round_after_ready(self) -> None:
         """Advance to the next hand with fixed dealer rotation and fresh action state."""


### PR DESCRIPTION
## 问题说明

简单麻将当前已经通过 `setup_random_seed_system` 得到整场游戏的 `master_seed`，但局种子仍使用 `room_random_seed or 1` 自行计算。

`room_random_seed` 只是在复式模式下由用户手动指定的可选主种子，默认值 `0` 表示未指定，不能直接作为牌山种子。原实现会在默认配置下固定退化为 `1`，同时绕过系统生成的 `master_seed`。

## 修改内容

- 引入公共方法 `derive_round_seed`。
- 将简单麻将的局种子改为 `derive_round_seed(self.master_seed, self.current_round)`。
- 保留现有 `setup_random_seed_system` 调用：用户指定非零种子时仍可复现；默认 `0` 时使用系统生成的主种子。

## 影响

- 默认模式下，牌山由系统生成的 `master_seed` 派生，不再使用固定回退值。
- 复式模式下，用户指定种子的可复现行为保持不变。
- 简单麻将与长沙、国标、青雀等规则共用相同的主种子到局种子派生逻辑。

## 验证

- `python -m py_compile open_mahjong_server/server/gamestate/game_jiandan/JiandanGameState.py`：通过。
- 按本次简单修复的范围要求，未新增测试文件。

## 审查顺序

1. `7f74a10d`：确认 `_derive_round_seed` 不再读取 `room_random_seed`，而是使用公共 `derive_round_seed(master_seed, current_round)`。

## AI 审查提示

请重点检查简单麻将的随机种子调用链：`room_random_seed` 是否只作为 `setup_random_seed_system` 的可选用户输入；默认值 `0` 时是否由系统生成 `master_seed`；每局牌山是否只使用 `derive_round_seed(self.master_seed, self.current_round)` 得到的局种子，并确认没有修改 `init_tiles.py` 或其它规则逻辑。
